### PR TITLE
Optimize foveated Gaussian splatting render path

### DIFF
--- a/builtin/shaders/include/common/gaussian_splat_foveated.glsl
+++ b/builtin/shaders/include/common/gaussian_splat_foveated.glsl
@@ -1,22 +1,27 @@
-vec2 gaussianFoveatedGazeNdc(const vec2 gazeUv)
+vec2 gaussianFoveatedUvToNdc(const vec2 uv, const float projectionYSign)
 {
-    return vec2(gazeUv.x * 2.0 - 1.0, 1.0 - gazeUv.y * 2.0);
+    return vec2(uv.x * 2.0 - 1.0, projectionYSign * (1.0 - uv.y * 2.0));
 }
 
 float gaussianFoveatedEccentricityDegreesFromNdc(const vec2 centerNdc,
                                                  const vec2 gazeUv,
-                                                 const vec2 tanHalfFov)
+                                                 const vec2 tanHalfFov,
+                                                 const float projectionYSign)
 {
-    const vec2 deltaTan = (centerNdc - gaussianFoveatedGazeNdc(gazeUv)) * max(tanHalfFov, vec2(1e-5));
+    const vec2 deltaTan = (centerNdc - gaussianFoveatedUvToNdc(gazeUv, projectionYSign)) * max(tanHalfFov, vec2(1e-5));
     return degrees(atan(length(deltaTan)));
 }
 
 float gaussianFoveatedEccentricityDegreesFromUv(const vec2 viewportUv,
                                                 const vec2 gazeUv,
-                                                const vec2 tanHalfFov)
+                                                const vec2 tanHalfFov,
+                                                const float projectionYSign)
 {
-    const vec2 centerNdc = vec2(viewportUv.x * 2.0 - 1.0, 1.0 - viewportUv.y * 2.0);
-    return gaussianFoveatedEccentricityDegreesFromNdc(centerNdc, gazeUv, tanHalfFov);
+    return gaussianFoveatedEccentricityDegreesFromNdc(
+        gaussianFoveatedUvToNdc(viewportUv, projectionYSign),
+        gazeUv,
+        tanHalfFov,
+        projectionYSign);
 }
 
 vec2 gaussianFoveatedRingBlend(const float eccentricityDegrees,

--- a/builtin/shaders/passes/general/gaussian_splat_foveated_composite.frag.vshader
+++ b/builtin/shaders/passes/general/gaussian_splat_foveated_composite.frag.vshader
@@ -73,6 +73,16 @@ vec3 overPremultiplied(const vec4 src, const vec3 dst)
     return src.rgb + dst * (1.0 - clamp(src.a, 0.0, 1.0));
 }
 
+vec2 foveatedViewportUv()
+{
+#if USE_MULTIVIEW && !PLATFORM_WEBGPU
+    const vec2 size = vec2(textureSize(t_FoveaLayer, 0).xy);
+#else
+    const vec2 size = vec2(textureSize(t_FoveaLayer, 0));
+#endif
+    return (gl_FragCoord.xy - vec2(0.5)) / max(size, vec2(1.0));
+}
+
 void main()
 {
     vec2 sampleUv = v_TexCoord;
@@ -81,7 +91,11 @@ void main()
 #endif
 
     const float eccentricityDegrees =
-        gaussianFoveatedEccentricityDegreesFromUv(sampleUv, u_PC.foveatedGazeAndRings.xy, u_PC.foveatedParams.xy);
+        gaussianFoveatedEccentricityDegreesFromUv(
+            foveatedViewportUv(),
+            u_PC.foveatedGazeAndRings.xy,
+            u_PC.foveatedParams.xy,
+            u_PC.foveatedParams.w == 0.0 ? 1.0 : u_PC.foveatedParams.w);
     const vec2 layerBlend =
         gaussianFoveatedRingBlend(eccentricityDegrees, u_PC.foveatedGazeAndRings.zw, u_PC.foveatedParams.z);
 

--- a/builtin/shaders/passes/general/gaussian_splat_foveated_debug_overlay.frag.vshader
+++ b/builtin/shaders/passes/general/gaussian_splat_foveated_debug_overlay.frag.vshader
@@ -1,0 +1,75 @@
+[vshader]
+language = glsl
+version = 460
+
+[keywords]
+USE_MULTIVIEW : bool permute
+
+[frag]
+#include "include/common/gaussian_splat_foveated.glsl"
+
+#if USE_MULTIVIEW && !PLATFORM_WEBGPU
+#extension GL_EXT_multiview : require
+#endif
+
+layout(location = 0) in vec2 v_TexCoord;
+layout(location = 0) out vec4 outColor;
+
+#if USE_MULTIVIEW && !PLATFORM_WEBGPU
+layout(set = 3, binding = 0) uniform sampler2DArray t_BaseLayer;
+#else
+layout(set = 3, binding = 0) uniform sampler2D t_BaseLayer;
+#endif
+
+layout(push_constant) uniform GeneralGaussianSplatFoveatedDebugOverlayPushConstants
+{
+    vec4 foveatedGazeAndRings;
+    vec4 foveatedParams;
+    vec4 debugParams;
+} u_PC;
+
+vec4 sampleBase(const vec2 uv)
+{
+#if USE_MULTIVIEW && !PLATFORM_WEBGPU
+    return texture(t_BaseLayer, vec3(uv, float(gl_ViewIndex)));
+#else
+    return texture(t_BaseLayer, uv);
+#endif
+}
+
+void main()
+{
+    vec2 sampleUv = v_TexCoord;
+#if PLATFORM_WEBGPU
+    sampleUv.y = 1.0 - sampleUv.y;
+#endif
+
+    const vec2 size = max(u_PC.debugParams.xy, vec2(1.0));
+    const vec2 viewportUv = (gl_FragCoord.xy - vec2(0.5)) / size;
+    const float projectionYSign = u_PC.foveatedParams.w == 0.0 ? 1.0 : u_PC.foveatedParams.w;
+    const float eccentricityDegrees =
+        gaussianFoveatedEccentricityDegreesFromUv(
+            viewportUv,
+            u_PC.foveatedGazeAndRings.xy,
+            u_PC.foveatedParams.xy,
+            projectionYSign);
+
+    const vec2 blend =
+        gaussianFoveatedRingBlend(eccentricityDegrees, u_PC.foveatedGazeAndRings.zw, u_PC.foveatedParams.z);
+    const vec3 overlay = mix(mix(vec3(1.0, 0.05, 0.05), vec3(0.0, 0.85, 0.20), blend.x),
+                             vec3(0.05, 0.25, 1.0),
+                             blend.y);
+
+    const float alpha = clamp(u_PC.debugParams.z, 0.0, 1.0);
+    const float dotRadius = max(u_PC.debugParams.w, 1.0);
+    const vec2 pixel = gl_FragCoord.xy - vec2(0.5);
+    const vec2 gazePixel = u_PC.foveatedGazeAndRings.xy * size;
+    const float dotMask = 1.0 - smoothstep(dotRadius, dotRadius + 1.5, length(pixel - gazePixel));
+    const float foveaLine = 1.0 - smoothstep(0.0, 0.35, abs(eccentricityDegrees - u_PC.foveatedGazeAndRings.z));
+    const float midLine = 1.0 - smoothstep(0.0, 0.35, abs(eccentricityDegrees - u_PC.foveatedGazeAndRings.w));
+
+    vec3 color = mix(sampleBase(sampleUv).rgb, overlay, alpha);
+    color = mix(color, vec3(1.0), max(foveaLine, midLine) * 0.70);
+    color = mix(color, vec3(1.0, 0.95, 0.0), dotMask);
+    outColor = vec4(color, 1.0);
+}

--- a/builtin/shaders/passes/general/gaussian_splat_preprocess.comp.vshader
+++ b/builtin/shaders/passes/general/gaussian_splat_preprocess.comp.vshader
@@ -36,6 +36,11 @@ const uint SORT_ORDER_Z_DEPTH = 0u;
 const uint SORT_ORDER_DISTANCE = 1u;
 const uint SORT_ORDER_VIEW_DEPTH = 2u;
 const uint SORT_ORDER_CONSERVATIVE_DEPTH = 3u;
+const uint FOVEATED_CLOD_ENABLED_FLAG = 1u;
+const uint FOVEATED_CLOD_COVERAGE_COMPENSATION_FLAG = 8u;
+const float FOVEATED_COVERAGE_MIN_LEVEL = 0.12;
+const float FOVEATED_COVERAGE_MAX_ALPHA_BOOST = 2.0;
+const float FOVEATED_COVERAGE_MAX_RADIUS_SCALE = 1.35;
 const float SH_C1 = 0.4886025119029199;
 const float SH_C2[5] = float[5](1.0925484305920792,
                                 -1.0925484305920792,
@@ -58,6 +63,7 @@ layout(push_constant) uniform GeneralGaussianSplatPreprocessPushConstants
     uint foveatedClodEnabled;
     vec4 foveatedGazeAndRings;
     vec4 foveatedLevelsAndTransition;
+    uvec4 foveatedLayerParams;
 } u_PC;
 
 struct EyePreprocessResult
@@ -76,7 +82,12 @@ float computeFoveatedEccentricityDegrees(const vec2 centerNdc, const CameraData 
 {
     const vec2 tanHalfFov = vec2(1.0 / max(abs(camera.projection[0][0]), 1e-5),
                                  1.0 / max(abs(camera.projection[1][1]), 1e-5));
-    return gaussianFoveatedEccentricityDegreesFromNdc(centerNdc, u_PC.foveatedGazeAndRings.xy, tanHalfFov);
+    const float projectionYSign = camera.projection[1][1] < 0.0 ? -1.0 : 1.0;
+    return gaussianFoveatedEccentricityDegreesFromNdc(
+        centerNdc,
+        u_PC.foveatedGazeAndRings.xy,
+        tanHalfFov,
+        projectionYSign);
 }
 
 float foveatedClodLevelForEccentricity(const float eccentricityDegrees)
@@ -87,14 +98,18 @@ float foveatedClodLevelForEccentricity(const float eccentricityDegrees)
                                      u_PC.foveatedLevelsAndTransition.w);
 }
 
+uint foveatedClodBudget(const float level)
+{
+    const uint rankTotalCount = max(u_PC.rankTotalCount, 1u);
+    return uint(ceil(float(rankTotalCount) * clamp(level, 0.0, 1.0)));
+}
+
 bool passesFoveatedClodLevel(const uint rank, const float level)
 {
-    if (u_PC.foveatedClodEnabled == 0u)
+    if ((u_PC.foveatedClodEnabled & FOVEATED_CLOD_ENABLED_FLAG) == 0u)
         return true;
 
-    const uint rankTotalCount = max(u_PC.rankTotalCount, 1u);
-    const uint budget = uint(ceil(float(rankTotalCount) * level));
-    return rank < budget;
+    return rank < foveatedClodBudget(level);
 }
 
 bool passesFoveatedLayerClod(const uint layer, const uint rank)
@@ -102,6 +117,41 @@ bool passesFoveatedLayerClod(const uint layer, const uint rank)
     const vec3 ringLevels = clamp(u_PC.foveatedLevelsAndTransition.xyz, vec3(0.0), vec3(1.0));
     const float layerLevel = layer == 0u ? ringLevels.x : (layer == 1u ? ringLevels.y : ringLevels.z);
     return passesFoveatedClodLevel(rank, layerLevel);
+}
+
+bool isInsideFoveatedLayerEccentricity(const uint layer, const float eccentricityDegrees)
+{
+    return gaussianFoveatedLayerContains(layer,
+                                         eccentricityDegrees,
+                                         u_PC.foveatedGazeAndRings.zw,
+                                         u_PC.foveatedLevelsAndTransition.w);
+}
+
+bool foveatedCoverageCompensationEnabled()
+{
+    return (u_PC.foveatedClodEnabled & FOVEATED_CLOD_COVERAGE_COMPENSATION_FLAG) != 0u;
+}
+
+float foveatedCoverageAlphaBoost(const float level)
+{
+    if (!foveatedCoverageCompensationEnabled())
+        return 1.0;
+
+    const float safeLevel = max(clamp(level, 0.0, 1.0), FOVEATED_COVERAGE_MIN_LEVEL);
+    return clamp(sqrt(1.0 / safeLevel), 1.0, FOVEATED_COVERAGE_MAX_ALPHA_BOOST);
+}
+
+float foveatedCoverageRadiusScale(const float level)
+{
+    const float boost = foveatedCoverageAlphaBoost(level);
+    return clamp(sqrt(boost), 1.0, FOVEATED_COVERAGE_MAX_RADIUS_SCALE);
+}
+
+float foveatedCoverageCompensatedOpacity(const float opacity, const float level)
+{
+    const float alpha = clamp(opacity, 0.0, 0.999);
+    const float boost = foveatedCoverageAlphaBoost(level);
+    return 1.0 - pow(1.0 - alpha, boost);
 }
 
 mat3 buildJacobian(const vec3 camspace, const vec2 focal)
@@ -229,14 +279,23 @@ EyePreprocessResult preprocessEye(const GeneralGaussianSplatPackedSource src,
         return result;
     if (posClip.x < -bounds || posClip.x > bounds || posClip.y < -bounds || posClip.y > bounds)
         return result;
-#if !USE_FOVEATED_LAYER_OUTPUT
     const float eccentricityDegrees = computeFoveatedEccentricityDegrees(centerNdc.xy, camera);
+#if !USE_FOVEATED_LAYER_OUTPUT
     if (!passesFoveatedClodLevel(rank, foveatedClodLevelForEccentricity(eccentricityDegrees)))
         return result;
     result.eccentricityDegrees = eccentricityDegrees;
 #else
-    result.eccentricityDegrees = computeFoveatedEccentricityDegrees(centerNdc.xy, camera);
+    if (u_PC.foveatedLayerParams.x != 0u &&
+        !isInsideFoveatedLayerEccentricity(u_PC.foveatedLayerParams.x - 1u, eccentricityDegrees))
+    {
+        return result;
+    }
+    result.eccentricityDegrees = eccentricityDegrees;
 #endif
+    const float foveatedCoverageLevel =
+        ((u_PC.foveatedClodEnabled & FOVEATED_CLOD_ENABLED_FLAG) != 0u) ?
+            foveatedClodLevelForEccentricity(eccentricityDegrees) :
+            1.0;
 
     const vec2 viewport = camera.resolution.xy;
     const vec2 focal =
@@ -258,6 +317,7 @@ EyePreprocessResult preprocessEye(const GeneralGaussianSplatPackedSource src,
         return result;
 
     colorOpacity.a *= sqrt(det0 / (det1 + 1e-6) + 1e-6);
+    colorOpacity.a = foveatedCoverageCompensatedOpacity(colorOpacity.a, foveatedCoverageLevel);
     if (colorOpacity.a < MIN_VISIBLE_OPACITY)
         return result;
 
@@ -276,8 +336,9 @@ EyePreprocessResult preprocessEye(const GeneralGaussianSplatPackedSource src,
         diagonalVector = normalize(diagonalVector);
 
     const float cutoffScale = max(draw.params0.y, 1e-3);
-    result.v1 = sqrt(2.0 * lambda1) * diagonalVector * cutoffScale;
-    result.v2 = sqrt(2.0 * lambda2) * vec2(diagonalVector.y, -diagonalVector.x) * cutoffScale;
+    const float coverageScale = foveatedCoverageRadiusScale(foveatedCoverageLevel);
+    result.v1 = sqrt(2.0 * lambda1) * diagonalVector * cutoffScale * coverageScale;
+    result.v2 = sqrt(2.0 * lambda2) * vec2(diagonalVector.y, -diagonalVector.x) * cutoffScale * coverageScale;
 
     const vec3 cameraWorld = camera.inverseView[3].xyz;
     vec3 dirLocal;
@@ -334,14 +395,6 @@ void packEyeResult(const EyePreprocessResult eye,
                     packHalf2x16(eye.colorOpacity.ba),
                     sourceIndex,
                     drawIndex);
-}
-
-bool isInsideFoveatedLayerEccentricity(const uint layer, const float eccentricityDegrees)
-{
-    return gaussianFoveatedLayerContains(layer,
-                                         eccentricityDegrees,
-                                         u_PC.foveatedGazeAndRings.zw,
-                                         u_PC.foveatedLevelsAndTransition.w);
 }
 
 float combinedFoveatedEccentricity(const EyePreprocessResult eye0, const EyePreprocessResult eye1)
@@ -506,13 +559,21 @@ void main()
 #endif
 
 #if USE_FOVEATED_LAYER_OUTPUT
-        const float eccentricityDegrees = combinedFoveatedEccentricity(eye0, eye1);
-        if (isInsideFoveatedLayerEccentricity(0u, eccentricityDegrees))
-            writeFoveatedLayerSplat(0u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
-        if (isInsideFoveatedLayerEccentricity(1u, eccentricityDegrees))
-            writeFoveatedLayerSplat(1u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
-        if (isInsideFoveatedLayerEccentricity(2u, eccentricityDegrees))
-            writeFoveatedLayerSplat(2u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
+        const uint activeLayer = u_PC.foveatedLayerParams.x;
+        if (activeLayer >= 1u && activeLayer <= 3u)
+        {
+            writeFoveatedLayerSplat(activeLayer - 1u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
+        }
+        else
+        {
+            const float eccentricityDegrees = combinedFoveatedEccentricity(eye0, eye1);
+            if (isInsideFoveatedLayerEccentricity(0u, eccentricityDegrees))
+                writeFoveatedLayerSplat(0u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
+            if (isInsideFoveatedLayerEccentricity(1u, eccentricityDegrees))
+                writeFoveatedLayerSplat(1u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
+            if (isInsideFoveatedLayerEccentricity(2u, eccentricityDegrees))
+                writeFoveatedLayerSplat(2u, eye0, eye1, sourceIndex, drawIndex, idx, sortDepth);
+        }
 #else
         const uint visibleIndex = atomicAdd(s_GeneralGaussianSplatVisibleCount.visibleCount, 1u);
         if (visibleIndex >= u_PC.maxVisibleSplats)

--- a/builtin/shaders/passes/general/gaussian_splat_render.frag.vshader
+++ b/builtin/shaders/passes/general/gaussian_splat_render.frag.vshader
@@ -5,6 +5,7 @@ version = 460
 [frag]
 #include "include/common/color.glsl"
 #include "include/common/gaussian_splat_foveated.glsl"
+
 const float CUTOFF = 2.3539888583335364;
 
 layout(location = 0) out vec4 outColor;
@@ -25,8 +26,14 @@ bool isInsideFoveatedLayer()
         return true;
 
     const vec2 viewportUv = (gl_FragCoord.xy - vec2(0.5)) / max(u_PC.targetSize.xy, vec2(1.0));
+    const float projectionYSign = u_PC.targetSize.z == 0.0 ? 1.0 : u_PC.targetSize.z;
     const float eccentricityDegrees =
-        gaussianFoveatedEccentricityDegreesFromUv(viewportUv, u_PC.foveatedGazeAndRings.xy, u_PC.foveatedParams.xy);
+        gaussianFoveatedEccentricityDegreesFromUv(
+            viewportUv,
+            u_PC.foveatedGazeAndRings.xy,
+            u_PC.foveatedParams.xy,
+            projectionYSign);
+
     return gaussianFoveatedLayerContains(layer - 1u,
                                          eccentricityDegrees,
                                          u_PC.foveatedGazeAndRings.zw,

--- a/examples/gaussian_splatting/gaussian_splatting_benchmark.hpp
+++ b/examples/gaussian_splatting/gaussian_splatting_benchmark.hpp
@@ -34,29 +34,37 @@ namespace vultra::gaussian_splatting_example
         uint32_t gpuScopeResolvedCount {0};
         uint32_t gpuScopeTokenCount {0};
 
-        GaussianSplatBaselineMode       baselineMode {GaussianSplatBaselineMode::eBaseline};
-        GaussianSplatFoveatedRenderMode foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
-        bool                            lodBudgetEnabled {false};
-        bool                            foveatedClodEnabled {false};
-        bool                            foveatedLayeredCompositeEnabled {false};
-        bool                            directPrefix {false};
-        uint32_t                        lodBudget {0};
-        float                           foveaLod {1.0};
-        float                           midLod {0.25};
-        float                           outerLod {0.05};
-        float                           foveaResolutionScale {1.0};
-        float                           midResolutionScale {0.5};
-        float                           outerResolutionScale {0.25};
-        bool                            adaptiveBudgetEnabled {false};
-        float                           targetFrameMs {11.1};
-        uint32_t                        splatAssets {0};
-        uint32_t                        drawRecords {0};
-        uint32_t                        totalSplats {0};
-        uint32_t                        preparedSplats {0};
-        uint32_t                        maxVisibleSplatCap {0};
-        uint32_t                        lodSelectedRawSplats {0};
-        uint32_t                        visibleSplats {UINT32_MAX};
-        uint32_t                        drawnSplats {UINT32_MAX};
+        GaussianSplatBaselineMode           baselineMode {GaussianSplatBaselineMode::eBaseline};
+        GaussianSplatFoveatedRenderMode     foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
+        GaussianSplatFoveatedAdaptationMode foveatedAdaptationMode {GaussianSplatFoveatedAdaptationMode::eFixed};
+        bool                                lodBudgetEnabled {false};
+        bool                                foveatedClodEnabled {false};
+        bool                                foveatedLayeredCompositeEnabled {false};
+        bool                                foveatedCoverageCompensationEnabled {false};
+        bool                                directPrefix {false};
+        uint32_t                            lodBudget {0};
+        float                               gazeX {0.5};
+        float                               gazeY {0.5};
+        float                               foveaLod {1.0};
+        float                               midLod {0.40};
+        float                               outerLod {0.15};
+        float                               foveaDegrees {8.0};
+        float                               midDegrees {24.0};
+        float                               foveaResolutionScale {1.0};
+        float                               midResolutionScale {0.75};
+        float                               outerResolutionScale {0.50};
+        float                               targetFrameMs {11.1};
+        uint32_t                            splatAssets {0};
+        uint32_t                            drawRecords {0};
+        uint32_t                            totalSplats {0};
+        uint32_t                            preparedSplats {0};
+        uint32_t                            foveaSplatBudget {0};
+        uint32_t                            midSplatBudget {0};
+        uint32_t                            outerSplatBudget {0};
+        uint32_t                            maxVisibleSplatCap {0};
+        uint32_t                            lodSelectedRawSplats {0};
+        uint32_t                            visibleSplats {UINT32_MAX};
+        uint32_t                            drawnSplats {UINT32_MAX};
 
         double cpuRenderFrameMs {-1.0};
         double cpuCookMs {-1.0};
@@ -107,6 +115,20 @@ namespace vultra::gaussian_splatting_example
         return "unknown";
     }
 
+    inline std::string_view foveatedAdaptationModeLabel(const GaussianSplatFoveatedAdaptationMode mode)
+    {
+        switch (mode)
+        {
+            case GaussianSplatFoveatedAdaptationMode::eFixed:
+                return "fixed";
+            case GaussianSplatFoveatedAdaptationMode::eDynamicBudget:
+                return "dynamic-budget";
+            case GaussianSplatFoveatedAdaptationMode::eDynamicRange:
+                return "dynamic-range";
+        }
+        return "unknown";
+    }
+
     inline double sumScopeMs(const std::vector<RuntimeProfiler::ScopeNode>& scopes,
                              const std::string_view                         needle,
                              const bool                                     useGpuMs)
@@ -151,23 +173,32 @@ namespace vultra::gaussian_splatting_example
 
         sample.baselineMode                     = gaussian.baselineMode;
         sample.foveatedRenderMode               = gaussian.foveatedRenderMode;
+        sample.foveatedAdaptationMode           = gaussian.foveatedAdaptationMode;
         sample.lodBudgetEnabled                 = gaussian.lodBudgetEnabled;
         sample.foveatedClodEnabled              = gaussian.foveatedClodEnabled;
         sample.foveatedLayeredCompositeEnabled  = gaussian.foveatedLayeredCompositeEnabled;
+        sample.foveatedCoverageCompensationEnabled =
+            gaussian.foveatedCoverageCompensationEnabled;
         sample.directPrefix                     = gaussian.directPrefix;
         sample.lodBudget                        = gaussian.lodBudget;
+        sample.gazeX                            = gaussian.foveatedGaze.x;
+        sample.gazeY                            = gaussian.foveatedGaze.y;
         sample.foveaLod                         = gaussian.foveatedRingLevels.x;
         sample.midLod                           = gaussian.foveatedRingLevels.y;
         sample.outerLod                         = gaussian.foveatedRingLevels.z;
+        sample.foveaDegrees                     = gaussian.foveatedRingDegrees.x;
+        sample.midDegrees                       = gaussian.foveatedRingDegrees.y;
         sample.foveaResolutionScale             = gaussian.foveatedResolutionScales.x;
         sample.midResolutionScale               = gaussian.foveatedResolutionScales.y;
         sample.outerResolutionScale             = gaussian.foveatedResolutionScales.z;
-        sample.adaptiveBudgetEnabled            = gaussian.foveatedBudgetControllerEnabled;
         sample.targetFrameMs                    = gaussian.foveatedTargetFrameMs;
         sample.splatAssets                      = gaussian.splatAssets;
         sample.drawRecords                      = gaussian.drawRecords;
         sample.totalSplats                      = gaussian.totalSplats;
         sample.preparedSplats                   = gaussian.preparedSplats;
+        sample.foveaSplatBudget                 = gaussian.foveaSplatBudget;
+        sample.midSplatBudget                   = gaussian.midSplatBudget;
+        sample.outerSplatBudget                 = gaussian.outerSplatBudget;
         sample.maxVisibleSplatCap               = gaussian.maxVisibleSplatCap;
         sample.lodSelectedRawSplats             = gaussian.lodSelectedRawSplats;
         sample.visibleSplats                    = gaussian.visibleSplats;
@@ -257,11 +288,12 @@ namespace vultra::gaussian_splatting_example
         }
 
         out << "sample,frame,mode,lod_budget_enabled,gaze_rendering,gaze_render_mode,layered_compositor,"
-               "direct_prefix,lod_budget,fovea_lod,mid_lod,outer_lod,fovea_res_scale,mid_res_scale,"
-               "outer_res_scale,adaptive_budget,target_frame_ms,dt_ms,cpu_frame_ms,cpu_render_ms,"
+               "coverage_compensation,direct_prefix,lod_budget,gaze_x,gaze_y,fovea_lod,mid_lod,outer_lod,fovea_deg,mid_deg,fovea_res_scale,mid_res_scale,"
+               "outer_res_scale,gaze_adaptation,target_frame_ms,dt_ms,cpu_frame_ms,cpu_render_ms,"
                "gpu_frame_ms,draw_calls,dispatch_calls,copy_ops,update_ops,gpu_scope_resolved_count,"
                "gpu_scope_token_count,splat_assets,draw_records,total_splats,prepared_splats,"
-               "max_visible_splat_cap,lod_selected_raw_splats,visible_splats,drawn_splats,"
+               "fovea_splat_budget,mid_splat_budget,outer_splat_budget,max_visible_splat_cap,"
+               "lod_selected_raw_splats,visible_splats,drawn_splats,"
                "cpu_render_frame_ms,cpu_cook_ms,cpu_gpu_scene_rebuild_ms,cpu_lod_selection_ms,"
                "cpu_clod_prefix_build_ms,cpu_raw_selection_ms,cpu_lod_upload_ms,cpu_framegraph_build_ms,"
                "cpu_framegraph_execute_ms,gpu_preprocess_pass_ms,gpu_project_cull_ms,gpu_sort_ms,"
@@ -275,15 +307,21 @@ namespace vultra::gaussian_splatting_example
                 << (sample.foveatedClodEnabled ? 1 : 0) << ','
                 << foveatedRenderModeLabel(sample.foveatedRenderMode) << ','
                 << (sample.foveatedLayeredCompositeEnabled ? 1 : 0) << ','
+                << (sample.foveatedCoverageCompensationEnabled ? 1 : 0) << ','
                 << (sample.directPrefix ? 1 : 0) << ','
-                << sample.lodBudget << ',' << sample.foveaLod << ',' << sample.midLod << ',' << sample.outerLod
-                << ',' << sample.foveaResolutionScale << ',' << sample.midResolutionScale << ','
-                << sample.outerResolutionScale << ',' << (sample.adaptiveBudgetEnabled ? 1 : 0) << ','
+                << sample.lodBudget << ',' << sample.gazeX << ',' << sample.gazeY << ','
+                << sample.foveaLod << ',' << sample.midLod << ',' << sample.outerLod
+                << ',' << sample.foveaDegrees << ',' << sample.midDegrees << ','
+                << sample.foveaResolutionScale << ',' << sample.midResolutionScale << ','
+                << sample.outerResolutionScale << ',' << foveatedAdaptationModeLabel(sample.foveatedAdaptationMode)
+                << ','
                 << sample.targetFrameMs << ',' << sample.dtMs << ',' << sample.cpuFrameMs << ',' << sample.cpuRenderMs
                 << ',' << sample.gpuFrameMs << ',' << sample.drawCalls << ',' << sample.dispatchCalls << ','
                 << sample.copyOps << ',' << sample.updateOps << ',' << sample.gpuScopeResolvedCount << ','
                 << sample.gpuScopeTokenCount << ',' << sample.splatAssets << ',' << sample.drawRecords << ','
-                << sample.totalSplats << ',' << sample.preparedSplats << ',' << sample.maxVisibleSplatCap << ','
+                << sample.totalSplats << ',' << sample.preparedSplats << ','
+                << sample.foveaSplatBudget << ',' << sample.midSplatBudget << ',' << sample.outerSplatBudget << ','
+                << sample.maxVisibleSplatCap << ','
                 << sample.lodSelectedRawSplats << ',' << csvCounter(sample.visibleSplats) << ','
                 << csvCounter(sample.drawnSplats) << ','
                 << sample.cpuRenderFrameMs << ',' << sample.cpuCookMs << ',' << sample.cpuGpuSceneRebuildMs << ','

--- a/examples/gaussian_splatting/main.cpp
+++ b/examples/gaussian_splatting/main.cpp
@@ -15,6 +15,7 @@
 #include "gaussian_splatting_benchmark.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdint>
 #include <filesystem>
@@ -38,6 +39,8 @@ namespace
         std::optional<uint32_t>                        lodBudget;
         std::optional<std::string>                     splatUri;
         std::optional<bool>                            foveatedClodEnabled;
+        std::optional<bool>                            foveatedCoverageCompensationEnabled;
+        std::optional<bool>                            foveatedDebugOverlayEnabled;
         std::optional<GaussianSplatFoveatedRenderMode> foveatedRenderMode;
         std::optional<float>                           gazeX;
         std::optional<float>                           gazeY;
@@ -50,9 +53,10 @@ namespace
         std::optional<float>                           midResolutionScale;
         std::optional<float>                           outerResolutionScale;
         std::optional<float>                           transitionDegrees;
-        std::optional<bool>                            adaptiveBudgetEnabled;
+        std::optional<GaussianSplatFoveatedAdaptationMode> foveatedAdaptationMode;
         std::optional<float>                           targetFrameMs;
         std::optional<float>                           budgetAdjustRate;
+        bool                                           fovGsBaselineEnabled {false};
 
         bool                  benchmarkEnabled {false};
         uint32_t              benchmarkFrames {300};
@@ -148,6 +152,18 @@ namespace
         return std::nullopt;
     }
 
+    std::optional<GaussianSplatFoveatedAdaptationMode> parseFoveatedAdaptationMode(const std::string_view value)
+    {
+        const auto normalized = normalizeToken(value);
+        if (normalized == "fixed")
+            return GaussianSplatFoveatedAdaptationMode::eFixed;
+        if (normalized == "dynamic-budget")
+            return GaussianSplatFoveatedAdaptationMode::eDynamicBudget;
+        if (normalized == "dynamic-range")
+            return GaussianSplatFoveatedAdaptationMode::eDynamicRange;
+        return std::nullopt;
+    }
+
     std::string splatUriFromCliValue(const std::string_view value)
     {
         const auto normalized = normalizeToken(value);
@@ -155,10 +171,12 @@ namespace
             return "res://models/3dgs/hornedlizard.spz";
         if (normalized == "racoonfamily")
             return "res://models/3dgs/racoonfamily.spz";
-        if (normalized == "train" || normalized == "truck" || normalized == "drjohnson" ||
-            normalized == "playroom")
+        constexpr std::array<std::string_view, 4> kResearchScenes {"train", "truck", "drjohnson", "playroom"};
+        for (const auto scene : kResearchScenes)
         {
-            return "res://models/3dgs/" + normalized + "/" + normalized + "_clod.ply";
+            const std::string sceneName {scene};
+            if (normalized == sceneName)
+                return "res://models/3dgs/" + sceneName + "/" + sceneName + "_clod.ply";
         }
 
         const std::string text {value};
@@ -268,6 +286,36 @@ namespace
                 continue;
             }
 
+            if (arg == "--fov-gs-baseline")
+            {
+                options.fovGsBaselineEnabled = true;
+                continue;
+            }
+
+            if (arg == "--coverage-compensation")
+            {
+                options.foveatedCoverageCompensationEnabled = true;
+                continue;
+            }
+
+            if (arg == "--no-coverage-compensation")
+            {
+                options.foveatedCoverageCompensationEnabled = false;
+                continue;
+            }
+
+            if (arg == "--gaze-debug-overlay")
+            {
+                options.foveatedDebugOverlayEnabled = true;
+                continue;
+            }
+
+            if (arg == "--no-gaze-debug-overlay")
+            {
+                options.foveatedDebugOverlayEnabled = false;
+                continue;
+            }
+
             if (const auto value = takeOptionValue(args, i, "--gaze-render-mode"))
             {
                 options.foveatedRenderMode = parseFoveatedRenderMode(*value);
@@ -276,15 +324,11 @@ namespace
                 continue;
             }
 
-            if (arg == "--adaptive-gaze-budget")
+            if (const auto value = takeOptionValue(args, i, "--gaze-adaptation"))
             {
-                options.adaptiveBudgetEnabled = true;
-                continue;
-            }
-
-            if (arg == "--no-adaptive-gaze-budget")
-            {
-                options.adaptiveBudgetEnabled = false;
+                options.foveatedAdaptationMode = parseFoveatedAdaptationMode(*value);
+                if (!options.foveatedAdaptationMode)
+                    VULTRA_CLIENT_WARN("Ignoring invalid --gaze-adaptation value: {}", *value);
                 continue;
             }
 
@@ -339,8 +383,11 @@ namespace
                options.foveaLod.has_value() || options.midLod.has_value() ||
                options.outerLod.has_value() || options.foveaResolutionScale.has_value() ||
                options.midResolutionScale.has_value() || options.outerResolutionScale.has_value() ||
-               options.transitionDegrees.has_value() || options.adaptiveBudgetEnabled.has_value() ||
-               options.targetFrameMs.has_value() || options.budgetAdjustRate.has_value();
+               options.transitionDegrees.has_value() || options.foveatedAdaptationMode.has_value() ||
+               options.foveatedCoverageCompensationEnabled.has_value() ||
+               options.foveatedDebugOverlayEnabled.has_value() ||
+               options.targetFrameMs.has_value() || options.budgetAdjustRate.has_value() ||
+               options.fovGsBaselineEnabled;
     }
 
     bool hasGazeRenderingOverride(const GaussianDemoOptions& options)
@@ -360,19 +407,24 @@ namespace
         settings.baselineMode                      = GaussianSplatBaselineMode::eOrderedClod;
         settings.clodLevel                         = 1.0f;
         settings.foveatedClodEnabled               = true;
+        settings.foveatedManualGazeControlEnabled  = false;
+        settings.foveatedCoverageCompensationEnabled = true;
+        settings.foveatedDebugOverlayEnabled       = false;
         settings.foveatedRenderMode               = GaussianSplatFoveatedRenderMode::eSinglePass;
         settings.foveatedGaze                     = glm::vec2 {0.5f, 0.5f};
-        settings.foveatedRingDegrees              = glm::vec2 {5.0f, 15.0f};
-        settings.foveatedRingLevels               = glm::vec3 {1.0f, 0.25f, 0.05f};
-        settings.foveatedResolutionScales         = glm::vec3 {1.0f, 0.5f, 0.25f};
-        settings.foveatedTransitionDegrees        = 2.0f;
-        settings.foveatedBudgetControllerEnabled  = false;
+        settings.foveatedRingDegrees              = glm::vec2 {8.0f, 24.0f};
+        settings.foveatedRingLevels               = glm::vec3 {1.0f, 0.40f, 0.15f};
+        settings.foveatedResolutionScales         = glm::vec3 {1.0f, 0.75f, 0.50f};
+        settings.foveatedTransitionDegrees        = 4.0f;
+        settings.foveatedAdaptationMode           = GaussianSplatFoveatedAdaptationMode::eFixed;
         settings.foveatedTargetFrameMs            = 11.1f;
         settings.foveatedBudgetAdjustRate         = 0.05f;
     }
 
     void applyGaussianDemoOptions(const GaussianDemoOptions& options, GaussianSplatRenderSettings& settings)
     {
+        if (options.fovGsBaselineEnabled)
+            applyGaussianSplatFovGsStyleBaseline(settings);
         if (options.mode)
             settings.baselineMode = *options.mode;
         if (options.clodLevel)
@@ -384,6 +436,10 @@ namespace
             settings.foveatedClodEnabled = true;
         if (options.foveatedClodEnabled.has_value())
             settings.foveatedClodEnabled = *options.foveatedClodEnabled;
+        if (options.foveatedCoverageCompensationEnabled.has_value())
+            settings.foveatedCoverageCompensationEnabled = *options.foveatedCoverageCompensationEnabled;
+        if (options.foveatedDebugOverlayEnabled.has_value())
+            settings.foveatedDebugOverlayEnabled = *options.foveatedDebugOverlayEnabled;
         if (options.foveatedRenderMode)
             settings.foveatedRenderMode = *options.foveatedRenderMode;
         if (options.gazeX)
@@ -410,8 +466,8 @@ namespace
             settings.foveatedResolutionScales.z = std::clamp(*options.outerResolutionScale, 0.05f, 1.0f);
         if (options.transitionDegrees)
             settings.foveatedTransitionDegrees = std::max(*options.transitionDegrees, 0.0f);
-        if (options.adaptiveBudgetEnabled)
-            settings.foveatedBudgetControllerEnabled = *options.adaptiveBudgetEnabled;
+        if (options.foveatedAdaptationMode)
+            settings.foveatedAdaptationMode = *options.foveatedAdaptationMode;
         if (options.targetFrameMs)
             settings.foveatedTargetFrameMs = std::max(*options.targetFrameMs, 0.1f);
         if (options.budgetAdjustRate)
@@ -521,6 +577,7 @@ protected:
             finishBenchmark();
             m_BenchmarkExitRequested = true;
             engineCtx().services.require<IWindowService>().window().close();
+            return;
         }
     }
 
@@ -560,15 +617,20 @@ private:
                   << "  mode: " << gaussianModeLabel(last.baselineMode) << "\n"
                   << "  gaze_rendering: " << (last.foveatedClodEnabled ? "yes" : "no") << "\n"
                   << "  gaze_render_mode: " << foveatedRenderModeLabel(last.foveatedRenderMode) << "\n"
+                  << "  coverage_compensation: " << (last.foveatedCoverageCompensationEnabled ? "yes" : "no") << "\n"
+                  << "  gaze_uv: " << last.gazeX << ", " << last.gazeY << "\n"
                   << "  layered_compositor: "
                   << (last.foveatedLayeredCompositeEnabled ? "yes" : "no") << "\n"
-                  << "  adaptive_budget: " << (last.adaptiveBudgetEnabled ? "yes" : "no") << "\n"
+                  << "  gaze_adaptation: " << foveatedAdaptationModeLabel(last.foveatedAdaptationMode) << "\n"
+                  << "  ring_degrees: " << last.foveaDegrees << ", " << last.midDegrees << "\n"
                   << "  ring_lod: " << last.foveaLod << ", " << last.midLod << ", " << last.outerLod << "\n"
                   << "  ring_res: " << last.foveaResolutionScale << ", " << last.midResolutionScale << ", "
                   << last.outerResolutionScale << "\n"
                   << "  direct_prefix: " << (last.directPrefix ? "yes" : "no") << "\n"
                   << "  splats: total=" << last.totalSplats << ", prepared=" << last.preparedSplats
-                  << ", selected_raw=" << last.lodSelectedRawSplats << "\n"
+                  << ", selected_raw=" << last.lodSelectedRawSplats
+                  << ", ring_budgets=" << last.foveaSplatBudget << "/" << last.midSplatBudget << "/"
+                  << last.outerSplatBudget << "\n"
                   << "  CPU frame: " << statsText(cpuFrameStats) << "\n"
                   << "  GPU frame: " << statsText(gpuFrameStats) << "\n"
                   << "  GPU preprocess pass: " << statsText(gpuPreprocess) << "\n"

--- a/source/vultra/include/vultra/function/rendering/render_structs.hpp
+++ b/source/vultra/include/vultra/function/rendering/render_structs.hpp
@@ -102,6 +102,13 @@ namespace vultra
         eLayeredComposite,
     };
 
+    enum class GaussianSplatFoveatedAdaptationMode : uint8_t
+    {
+        eFixed = 0,
+        eDynamicBudget,
+        eDynamicRange,
+    };
+
     inline constexpr uint32_t kGaussianSplatFoveatedLayerCount =
         resource::kGeneralGaussianSplatFoveatedLayerCount;
 
@@ -114,19 +121,22 @@ namespace vultra
 
     struct GaussianSplatRenderSettings
     {
-        GaussianSplatBaselineMode       baselineMode {GaussianSplatBaselineMode::eBaseline};
-        uint32_t                        lodBudget {0}; // 0 means derive the selected count from clodLevel.
-        float                           clodLevel {1.0f}; // Fraction of the ordered list to keep when lodBudget is automatic.
-        bool                            foveatedClodEnabled {false};
-        GaussianSplatFoveatedRenderMode foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
-        glm::vec2                       foveatedGaze {0.5f, 0.5f}; // Viewport UV, top-left origin.
-        glm::vec2                       foveatedRingDegrees {5.0f, 15.0f};
-        glm::vec3                       foveatedRingLevels {1.0f, 0.25f, 0.05f};
-        glm::vec3                       foveatedResolutionScales {1.0f, 0.5f, 0.25f};
-        float                           foveatedTransitionDegrees {2.0f};
-        bool                            foveatedBudgetControllerEnabled {false};
-        float                           foveatedTargetFrameMs {11.1f};
-        float                           foveatedBudgetAdjustRate {0.05f};
+        GaussianSplatBaselineMode           baselineMode {GaussianSplatBaselineMode::eBaseline};
+        uint32_t                            lodBudget {0}; // 0 means derive the selected count from clodLevel.
+        float                               clodLevel {1.0f}; // Fraction of the ordered list to keep when lodBudget is automatic.
+        bool                                foveatedClodEnabled {false};
+        bool                                foveatedManualGazeControlEnabled {false};
+        bool                                foveatedCoverageCompensationEnabled {true};
+        bool                                foveatedDebugOverlayEnabled {false};
+        GaussianSplatFoveatedRenderMode     foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
+        glm::vec2                           foveatedGaze {0.5f, 0.5f}; // Viewport UV, top-left origin.
+        glm::vec2                           foveatedRingDegrees {8.0f, 24.0f};
+        glm::vec3                           foveatedRingLevels {1.0f, 0.40f, 0.15f};
+        glm::vec3                           foveatedResolutionScales {1.0f, 0.75f, 0.50f};
+        float                               foveatedTransitionDegrees {4.0f};
+        GaussianSplatFoveatedAdaptationMode foveatedAdaptationMode {GaussianSplatFoveatedAdaptationMode::eFixed};
+        float                               foveatedTargetFrameMs {11.1f};
+        float                               foveatedBudgetAdjustRate {0.05f};
 
         [[nodiscard]] std::array<GaussianSplatFoveatedLayerConfig, kGaussianSplatFoveatedLayerCount> foveatedLayers() const
         {
@@ -170,26 +180,49 @@ namespace vultra
         }
     };
 
+    inline void applyGaussianSplatFovGsStyleBaseline(GaussianSplatRenderSettings& settings)
+    {
+        settings.baselineMode                     = GaussianSplatBaselineMode::eOrderedClod;
+        settings.lodBudget                        = 0u;
+        settings.clodLevel                        = 1.0f;
+        settings.foveatedClodEnabled              = true;
+        settings.foveatedManualGazeControlEnabled = false;
+        settings.foveatedCoverageCompensationEnabled = false;
+        settings.foveatedDebugOverlayEnabled      = false;
+        settings.foveatedRenderMode               = GaussianSplatFoveatedRenderMode::eSinglePass;
+        settings.foveatedRingDegrees              = glm::vec2 {10.0f, 42.0f};
+        settings.foveatedRingLevels               = glm::vec3 {1.0f, 0.25f, 0.125f};
+        settings.foveatedResolutionScales         = glm::vec3 {1.0f, 1.0f, 1.0f};
+        settings.foveatedTransitionDegrees        = 4.0f;
+        settings.foveatedAdaptationMode           = GaussianSplatFoveatedAdaptationMode::eFixed;
+    }
+
     struct GaussianSplatFrameStats
     {
-        uint64_t                        frameIndex {0};
-        GaussianSplatBaselineMode       baselineMode {GaussianSplatBaselineMode::eBaseline};
-        GaussianSplatFoveatedRenderMode foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
-        bool                            lodBudgetEnabled {false};
-        bool                            foveatedClodEnabled {false};
-        bool                            foveatedLayeredCompositeEnabled {false};
-        bool                            foveatedBudgetControllerEnabled {false};
-        bool                            directPrefix {false};
-        uint32_t                        lodBudget {0};
-        glm::vec3                       foveatedRingLevels {1.0f, 0.25f, 0.05f};
-        glm::vec3                       foveatedResolutionScales {1.0f, 0.5f, 0.25f};
-        glm::vec2                       foveatedRingDegrees {5.0f, 15.0f};
-        float                           foveatedTargetFrameMs {11.1f};
+        uint64_t                            frameIndex {0};
+        GaussianSplatBaselineMode           baselineMode {GaussianSplatBaselineMode::eBaseline};
+        GaussianSplatFoveatedRenderMode     foveatedRenderMode {GaussianSplatFoveatedRenderMode::eSinglePass};
+        bool                                lodBudgetEnabled {false};
+        bool                                foveatedClodEnabled {false};
+        bool                                foveatedLayeredCompositeEnabled {false};
+        bool                                foveatedCoverageCompensationEnabled {false};
+        bool                                foveatedDebugOverlayEnabled {false};
+        GaussianSplatFoveatedAdaptationMode foveatedAdaptationMode {GaussianSplatFoveatedAdaptationMode::eFixed};
+        bool                                directPrefix {false};
+        uint32_t                            lodBudget {0};
+        glm::vec3                           foveatedRingLevels {1.0f, 0.40f, 0.15f};
+        glm::vec3                           foveatedResolutionScales {1.0f, 0.75f, 0.50f};
+        glm::vec2                           foveatedGaze {0.5f, 0.5f};
+        glm::vec2                           foveatedRingDegrees {8.0f, 24.0f};
+        float                               foveatedTargetFrameMs {11.1f};
 
         uint32_t splatAssets {0};
         uint32_t drawRecords {0};
         uint32_t totalSplats {0};
         uint32_t preparedSplats {0};
+        uint32_t foveaSplatBudget {0};
+        uint32_t midSplatBudget {0};
+        uint32_t outerSplatBudget {0};
         uint32_t maxVisibleSplatCap {0};
         uint32_t lodSelectedRawSplats {0};
 

--- a/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_foveated_composite_pass.hpp
+++ b/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_foveated_composite_pass.hpp
@@ -19,6 +19,11 @@ namespace vultra
                                    FrameGraphResource      outerLayer,
                                    FrameGraphResource      baseColor = {});
 
-        rhi::GraphicsPipeline createPipeline(rhi::PixelFormat colorFormat, bool useMultiview, bool useBase) const;
+        FrameGraphResource debugOverlay(FrameGraphBuildContext& ctx, FrameGraphResource baseColor);
+
+        rhi::GraphicsPipeline createPipeline(rhi::PixelFormat colorFormat,
+                                             bool             useMultiview,
+                                             bool             useBase,
+                                             bool             debugOverlay) const;
     };
 } // namespace vultra

--- a/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_preprocess_pass.hpp
+++ b/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_preprocess_pass.hpp
@@ -12,7 +12,9 @@ namespace vultra
 
         void addPass(FrameGraphBuildContext& ctx);
 
-        rhi::ComputePipeline createPipeline(bool useMultiview, bool useDirectPrefix, bool useFoveatedLayerOutput) const;
+        rhi::ComputePipeline createPipeline(bool useMultiview,
+                                            bool useDirectPrefix,
+                                            bool useFoveatedLayerOutput) const;
         rhi::ComputePipeline createPipeline(uint64_t variantHash) const;
     };
 } // namespace vultra

--- a/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_render_pass.hpp
+++ b/source/vultra/include/vultra/function/rendering/srp/builtin/passes/general_gaussian_splat_render_pass.hpp
@@ -24,8 +24,10 @@ namespace vultra
         FrameGraphResource addPass(FrameGraphBuildContext& ctx);
         FrameGraphResource addFoveatedLayerPass(FrameGraphBuildContext&           ctx,
                                                 GeneralGaussianSplatFoveatedLayer layer,
-                                                rhi::Extent2D                    resolution);
+                                                rhi::Extent2D                    resolution,
+                                                FrameGraphResource               existingColor = {});
 
-        rhi::GraphicsPipeline createPipeline(rhi::PixelFormat colorFormat, bool useMultiview) const;
+        rhi::GraphicsPipeline createPipeline(rhi::PixelFormat colorFormat,
+                                             bool             useMultiview) const;
     };
 } // namespace vultra

--- a/source/vultra/include/vultra/function/resource/gpu_scene_view.hpp
+++ b/source/vultra/include/vultra/function/resource/gpu_scene_view.hpp
@@ -109,11 +109,13 @@ namespace vultra::resource
         bool      generalGaussianSplatDirectPrefix {false};
         bool      generalGaussianSplatFoveatedClodEnabled {false};
         bool      generalGaussianSplatFoveatedLayeredCompositeEnabled {false};
+        bool      generalGaussianSplatFoveatedCoverageCompensationEnabled {false};
+        bool      generalGaussianSplatFoveatedDebugOverlayEnabled {false};
         glm::vec2 generalGaussianSplatFoveatedGaze {0.5f, 0.5f};
-        glm::vec2 generalGaussianSplatFoveatedRingDegrees {5.0f, 15.0f};
-        glm::vec3 generalGaussianSplatFoveatedRingLevels {1.0f, 0.25f, 0.05f};
-        glm::vec3 generalGaussianSplatFoveatedResolutionScales {1.0f, 0.5f, 0.25f};
-        float     generalGaussianSplatFoveatedTransitionDegrees {2.0f};
+        glm::vec2 generalGaussianSplatFoveatedRingDegrees {8.0f, 24.0f};
+        glm::vec3 generalGaussianSplatFoveatedRingLevels {1.0f, 0.40f, 0.15f};
+        glm::vec3 generalGaussianSplatFoveatedResolutionScales {1.0f, 0.75f, 0.50f};
+        float     generalGaussianSplatFoveatedTransitionDegrees {4.0f};
 
         void clear()
         {
@@ -415,6 +417,8 @@ namespace vultra::resource
 
         void setGeneralGaussianSplatFoveatedClod(bool enabled,
                                                  bool layeredCompositeEnabled,
+                                                 bool coverageCompensationEnabled,
+                                                 bool debugOverlayEnabled,
                                                  glm::vec2 gaze,
                                                  glm::vec2 ringDegrees,
                                                  glm::vec3 ringLevels,
@@ -423,6 +427,9 @@ namespace vultra::resource
         {
             generalGaussianSplatFoveatedClodEnabled              = enabled;
             generalGaussianSplatFoveatedLayeredCompositeEnabled = layeredCompositeEnabled;
+            generalGaussianSplatFoveatedCoverageCompensationEnabled =
+                coverageCompensationEnabled;
+            generalGaussianSplatFoveatedDebugOverlayEnabled      = debugOverlayEnabled;
             generalGaussianSplatFoveatedGaze                     = gaze;
             generalGaussianSplatFoveatedRingDegrees              = ringDegrees;
             generalGaussianSplatFoveatedRingLevels               = ringLevels;
@@ -434,11 +441,13 @@ namespace vultra::resource
         {
             setGeneralGaussianSplatFoveatedClod(false,
                                                 false,
+                                                false,
+                                                false,
                                                 glm::vec2 {0.5f, 0.5f},
-                                                glm::vec2 {5.0f, 15.0f},
-                                                glm::vec3 {1.0f, 0.25f, 0.05f},
-                                                glm::vec3 {1.0f, 0.5f, 0.25f},
-                                                2.0f);
+                                                glm::vec2 {8.0f, 24.0f},
+                                                glm::vec3 {1.0f, 0.40f, 0.15f},
+                                                glm::vec3 {1.0f, 0.75f, 0.50f},
+                                                4.0f);
         }
 
         void ensureGeneralGaussianSplatBuffers(rhi::RenderDevice& rd)

--- a/source/vultra/src/function/rendering/render_system.cpp
+++ b/source/vultra/src/function/rendering/render_system.cpp
@@ -107,6 +107,8 @@ namespace vultra
             const auto layers = settings.foveatedLayers();
             gpuSceneView.setGeneralGaussianSplatFoveatedClod(settings.foveatedClodActive(),
                                                              settings.foveatedLayeredCompositeActive(),
+                                                             settings.foveatedCoverageCompensationEnabled,
+                                                             settings.foveatedDebugOverlayEnabled,
                                                              settings.foveatedGaze,
                                                              glm::vec2 {layers[0].eccentricityDegrees,
                                                                         layers[1].eccentricityDegrees},
@@ -125,6 +127,8 @@ namespace vultra
             return current.lodBudget != applied.lodBudget ||
                    current.clodLevel != applied.clodLevel ||
                    current.foveatedClodEnabled != applied.foveatedClodEnabled ||
+                   current.foveatedCoverageCompensationEnabled != applied.foveatedCoverageCompensationEnabled ||
+                   current.foveatedDebugOverlayEnabled != applied.foveatedDebugOverlayEnabled ||
                    current.foveatedRenderMode != applied.foveatedRenderMode ||
                    current.foveatedGaze != applied.foveatedGaze ||
                    current.foveatedRingDegrees != applied.foveatedRingDegrees ||
@@ -133,29 +137,81 @@ namespace vultra
                    current.foveatedTransitionDegrees != applied.foveatedTransitionDegrees;
         }
 
-        void updateGaussianSplatFoveatedBudgetController(GaussianSplatRenderSettings& settings,
-                                                         const double                 gpuFrameMs)
+        uint32_t gaussianSplatBudgetFromLevel(const uint32_t totalSplatCount, const float level)
         {
-            if (!settings.foveatedClodActive() || !settings.foveatedBudgetControllerEnabled || gpuFrameMs <= 0.0)
-                return;
+            if (totalSplatCount == 0u)
+                return 0u;
+            const float clamped = std::clamp(level, 0.0f, 1.0f);
+            return std::min(totalSplatCount,
+                            std::max(1u, static_cast<uint32_t>(
+                                             std::ceil(static_cast<float>(totalSplatCount) * clamped))));
+        }
+
+        bool gaussianSplatFoveatedFrameTimeFeedback(const GaussianSplatRenderSettings& settings,
+                                                    const double                       gpuFrameMs,
+                                                    float&                             error,
+                                                    float&                             step)
+        {
+            if (!settings.foveatedClodActive() || gpuFrameMs <= 0.0)
+                return false;
 
             const float targetMs = std::max(settings.foveatedTargetFrameMs, 0.1f);
             const float maxStep = std::clamp(settings.foveatedBudgetAdjustRate, 0.001f, 0.25f);
-            const float error = static_cast<float>((targetMs - gpuFrameMs) / targetMs);
+            error = static_cast<float>((targetMs - gpuFrameMs) / targetMs);
             if (std::abs(error) < 0.03f)
+                return false;
+
+            step = std::clamp(error * 0.5f, -maxStep, maxStep);
+            return true;
+        }
+
+        void updateGaussianSplatFoveatedAdaptation(GaussianSplatRenderSettings& settings, const double gpuFrameMs)
+        {
+            float error = 0.0f;
+            float step  = 0.0f;
+            if (!gaussianSplatFoveatedFrameTimeFeedback(settings, gpuFrameMs, error, step))
                 return;
 
-            const float signedStep = std::clamp(error * 0.5f, -maxStep, maxStep);
-            auto adjust = [signedStep](float value, const float floorValue) {
-                return std::clamp(value + signedStep * std::max(value, 0.1f), floorValue, 1.0f);
+            auto adjustBudget = [](float value, const float step, const float floorValue) {
+                return std::clamp(value + step * std::max(value, 0.1f), floorValue, 1.0f);
+            };
+            auto adjustRange = [](const float value, const float step, const float floorValue, const float ceilingValue) {
+                return std::clamp(value + step * std::max(value, 1.0f), floorValue, ceilingValue);
+            };
+            auto clampRings = [&settings]() {
+                settings.foveatedRingLevels.z = std::clamp(settings.foveatedRingLevels.z, 0.01f, 1.0f);
+                settings.foveatedRingLevels.y =
+                    std::clamp(settings.foveatedRingLevels.y, settings.foveatedRingLevels.z, 1.0f);
+                settings.foveatedRingLevels.x =
+                    std::clamp(settings.foveatedRingLevels.x, settings.foveatedRingLevels.y, 1.0f);
+                settings.foveatedRingDegrees.x = std::clamp(settings.foveatedRingDegrees.x, 1.0f, 45.0f);
+                settings.foveatedRingDegrees.y =
+                    std::clamp(settings.foveatedRingDegrees.y, settings.foveatedRingDegrees.x, 90.0f);
             };
 
-            settings.foveatedRingLevels.z = adjust(settings.foveatedRingLevels.z, 0.01f);
-            settings.foveatedRingLevels.y = adjust(settings.foveatedRingLevels.y, settings.foveatedRingLevels.z);
-            if (error < -0.35f)
-                settings.foveatedRingLevels.x = adjust(settings.foveatedRingLevels.x, settings.foveatedRingLevels.y);
-            else
-                settings.foveatedRingLevels.x = std::max(settings.foveatedRingLevels.x, settings.foveatedRingLevels.y);
+            switch (settings.foveatedAdaptationMode)
+            {
+                case GaussianSplatFoveatedAdaptationMode::eFixed:
+                    break;
+                case GaussianSplatFoveatedAdaptationMode::eDynamicBudget:
+                    settings.foveatedRingLevels.z = adjustBudget(settings.foveatedRingLevels.z, step, 0.01f);
+                    settings.foveatedRingLevels.y =
+                        adjustBudget(settings.foveatedRingLevels.y, step, settings.foveatedRingLevels.z);
+                    if (error < -0.35f)
+                        settings.foveatedRingLevels.x =
+                            adjustBudget(settings.foveatedRingLevels.x, step, settings.foveatedRingLevels.y);
+                    else
+                        settings.foveatedRingLevels.x =
+                            std::max(settings.foveatedRingLevels.x, settings.foveatedRingLevels.y);
+                    clampRings();
+                    break;
+                case GaussianSplatFoveatedAdaptationMode::eDynamicRange:
+                    settings.foveatedRingDegrees.x = adjustRange(settings.foveatedRingDegrees.x, step, 1.0f, 45.0f);
+                    settings.foveatedRingDegrees.y =
+                        adjustRange(settings.foveatedRingDegrees.y, step, settings.foveatedRingDegrees.x, 90.0f);
+                    clampRings();
+                    break;
+            }
         }
 
         void rebuildGaussianSplatOrderedClodPrefixSources(resource::GpuSceneView&                       gpuSceneView,
@@ -519,14 +575,28 @@ namespace vultra
         gaussianStats.lodBudgetEnabled                 = m_GaussianSplatSettings.lodBudgetEnabled();
         gaussianStats.foveatedClodEnabled              = m_GaussianSplatSettings.foveatedClodActive();
         gaussianStats.foveatedLayeredCompositeEnabled = m_GaussianSplatSettings.foveatedLayeredCompositeActive();
-        gaussianStats.foveatedBudgetControllerEnabled = m_GaussianSplatSettings.foveatedBudgetControllerEnabled;
+        gaussianStats.foveatedCoverageCompensationEnabled =
+            m_GaussianSplatSettings.foveatedCoverageCompensationEnabled;
+        gaussianStats.foveatedDebugOverlayEnabled =
+            m_GaussianSplatSettings.foveatedDebugOverlayEnabled;
+        gaussianStats.foveatedAdaptationMode           = m_GaussianSplatSettings.foveatedAdaptationMode;
         gaussianStats.lodBudget                        = m_GaussianSplatSettings.lodBudget;
         gaussianStats.foveatedRingLevels               = m_GaussianSplatSettings.foveatedRingLevels;
         gaussianStats.foveatedResolutionScales         = m_GaussianSplatSettings.foveatedResolutionScales;
+        gaussianStats.foveatedGaze                     = m_GaussianSplatSettings.foveatedGaze;
         gaussianStats.foveatedRingDegrees              = m_GaussianSplatSettings.foveatedRingDegrees;
         gaussianStats.foveatedTargetFrameMs            = m_GaussianSplatSettings.foveatedTargetFrameMs;
         gaussianStats.splatAssets                      = static_cast<uint32_t>(m_RenderWorldBack.gaussianSplats.size());
         gaussianStats.totalSplats                      = maxGeneralGaussianSplatPoints;
+        if (m_GaussianSplatSettings.foveatedClodActive())
+        {
+            gaussianStats.foveaSplatBudget =
+                gaussianSplatBudgetFromLevel(maxGeneralGaussianSplatPoints, m_GaussianSplatSettings.foveatedRingLevels.x);
+            gaussianStats.midSplatBudget =
+                gaussianSplatBudgetFromLevel(maxGeneralGaussianSplatPoints, m_GaussianSplatSettings.foveatedRingLevels.y);
+            gaussianStats.outerSplatBudget =
+                gaussianSplatBudgetFromLevel(maxGeneralGaussianSplatPoints, m_GaussianSplatSettings.foveatedRingLevels.z);
+        }
 
         const bool gaussianModeSettingsDirty =
             m_GaussianSplatSettings.baselineMode != m_AppliedGaussianSplatSettings.baselineMode;
@@ -1298,7 +1368,7 @@ namespace vultra
         m_RuntimeProfiler.setCpuRenderMs(
             std::chrono::duration<double, std::milli>(renderFrameCpuEnd - renderFrameCpuStart).count());
         m_RuntimeProfiler.endFrame();
-        updateGaussianSplatFoveatedBudgetController(m_GaussianSplatSettings, gpuFrameMs);
+        updateGaussianSplatFoveatedAdaptation(m_GaussianSplatSettings, gpuFrameMs);
         rhi::setBuiltinProfilerGpuScopeCallbacks({}, {});
         m_RuntimeProfiler.setGpuScopeCallbacks({}, {}, {});
 

--- a/source/vultra/src/function/rendering/srp/builtin/features/general_gaussian_splat_feature.cpp
+++ b/source/vultra/src/function/rendering/srp/builtin/features/general_gaussian_splat_feature.cpp
@@ -42,6 +42,16 @@ namespace vultra
         if (!gpuSceneView || !gpuSceneView->hasGeneralGaussianSplats())
             return;
 
+        auto setFinalColor = [&](FrameGraphResource color) {
+            if (gpuSceneView->generalGaussianSplatFoveatedDebugOverlayEnabled && color)
+            {
+                if (auto overlay = m_FoveatedCompositePass->debugOverlay(ctx, color))
+                    color = overlay;
+            }
+            if (color)
+                ctx.data.set(kResKey_FinalCompositionSource, color);
+        };
+
         m_PreprocessPass->addPass(ctx);
         if (gpuSceneView->generalGaussianSplatFoveatedLayeredCompositeEnabled)
         {
@@ -59,13 +69,11 @@ namespace vultra
                                                                   scaleExtent(ctx.view().extent,
                                                                               gpuSceneView->generalGaussianSplatFoveatedResolutionScales.z));
             auto color = m_FoveatedCompositePass->compose(ctx, fovea, mid, outer, baseColor);
-            if (color)
-                ctx.data.set(kResKey_FinalCompositionSource, color);
+            setFinalColor(color);
             return;
         }
 
         auto color = m_RenderPass->addPass(ctx);
-        if (color)
-            ctx.data.set(kResKey_FinalCompositionSource, color);
+        setFinalColor(color);
     }
 } // namespace vultra

--- a/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_foveated_composite_pass.cpp
+++ b/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_foveated_composite_pass.cpp
@@ -19,8 +19,15 @@ namespace vultra
 
         struct GeneralGaussianSplatFoveatedCompositePushConstants
         {
-            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 5.0f, 15.0f};
-            glm::vec4 foveatedParams {1.0f, 1.0f, 2.0f, 0.0f};
+            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 8.0f, 24.0f};
+            glm::vec4 foveatedParams {1.0f, 1.0f, 4.0f, 1.0f};
+        };
+
+        struct GeneralGaussianSplatFoveatedDebugOverlayPushConstants
+        {
+            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 8.0f, 24.0f};
+            glm::vec4 foveatedParams {1.0f, 1.0f, 4.0f, 1.0f};
+            glm::vec4 debugParams {1.0f, 1.0f, 0.30f, 6.0f};
         };
 
         [[nodiscard]] glm::vec2 foveatedTanHalfFov(const RenderView& view)
@@ -33,11 +40,24 @@ namespace vultra
                               1.0f / std::max(std::abs(projection[1][1]), 1e-5f)};
         }
 
+        [[nodiscard]] float foveatedProjectionYSign(const RenderView& view, const rhi::RenderBackendApi backendApi)
+        {
+            if (!view.camera)
+                return 1.0f;
+
+            float sign = view.camera->projection[1][1] < 0.0f ? -1.0f : 1.0f;
+            if (backendApi == rhi::RenderBackendApi::eVulkan)
+                sign *= -1.0f;
+            return sign;
+        }
+
         [[nodiscard]] GeneralGaussianSplatFoveatedCompositePushConstants makeCompositePushConstants(
             const RenderView&             view,
-            const resource::GpuSceneView& gpuSceneView)
+            const resource::GpuSceneView& gpuSceneView,
+            const rhi::RenderBackendApi   backendApi)
         {
             const glm::vec2 tanHalfFov = foveatedTanHalfFov(view);
+            const float projectionYSign = foveatedProjectionYSign(view, backendApi);
 
             GeneralGaussianSplatFoveatedCompositePushConstants pc {};
             pc.foveatedGazeAndRings =
@@ -49,9 +69,29 @@ namespace vultra
                 glm::vec4 {tanHalfFov.x,
                            tanHalfFov.y,
                            std::max(gpuSceneView.generalGaussianSplatFoveatedTransitionDegrees, 0.0f),
-                           0.0f};
+                           projectionYSign};
             return pc;
         }
+
+        [[nodiscard]] GeneralGaussianSplatFoveatedDebugOverlayPushConstants makeDebugOverlayPushConstants(
+            const RenderView&             view,
+            const resource::GpuSceneView& gpuSceneView,
+            const rhi::Extent2D           resolution,
+            const rhi::RenderBackendApi   backendApi)
+        {
+            const auto base = makeCompositePushConstants(view, gpuSceneView, backendApi);
+            GeneralGaussianSplatFoveatedDebugOverlayPushConstants pc {};
+            pc.foveatedGazeAndRings = base.foveatedGazeAndRings;
+            pc.foveatedParams       = base.foveatedParams;
+            pc.debugParams = glm::vec4 {
+                static_cast<float>(std::max(resolution.width, 1u)),
+                static_cast<float>(std::max(resolution.height, 1u)),
+                0.30f,
+                6.0f,
+            };
+            return pc;
+        }
+
     } // namespace
 
     GeneralGaussianSplatFoveatedCompositePass::GeneralGaussianSplatFoveatedCompositePass()
@@ -72,7 +112,7 @@ namespace vultra
         const bool useBase = static_cast<bool>(baseColor);
         const bool useMultiview = ctx.view().enableMultiview && ctx.view().multiviewCameraCount >= 2u;
         const auto resolution = ctx.view().extent;
-        const auto pushConstants = makeCompositePushConstants(ctx.view(), *gpuSceneView);
+        const auto pushConstants = makeCompositePushConstants(ctx.view(), *gpuSceneView, ctx.rd.getBackendApi());
 
         struct PassData
         {
@@ -165,7 +205,8 @@ namespace vultra
 
                 const auto* pipeline = getPipeline(rhi::getColorFormat(rc.framebufferInfo().value(), 0),
                                                    useMultiview,
-                                                   useBase);
+                                                   useBase,
+                                                   false);
                 if (!pipeline)
                     return;
 
@@ -191,10 +232,98 @@ namespace vultra
         return data.color;
     }
 
+    FrameGraphResource GeneralGaussianSplatFoveatedCompositePass::debugOverlay(FrameGraphBuildContext& ctx,
+                                                                               FrameGraphResource      baseColor)
+    {
+        auto* gpuSceneView = ctx.view().gpuSceneView;
+        if (!gpuSceneView || !baseColor)
+            return {};
+
+        const bool useMultiview = ctx.view().enableMultiview && ctx.view().multiviewCameraCount >= 2u;
+        const auto resolution = ctx.view().extent;
+        const auto pushConstants =
+            makeDebugOverlayPushConstants(ctx.view(), *gpuSceneView, resolution, ctx.rd.getBackendApi());
+
+        struct PassData
+        {
+            FrameGraphResource color;
+            FrameGraphResource baseColor;
+        };
+
+        auto data = ctx.fg.addCallbackPass<PassData>(
+            "GeneralGaussianSplatFoveatedDebugOverlayPass",
+            [resolution, useMultiview, baseColor](FrameGraph::Builder& builder, PassData& data) {
+                PASS_SETUP_ZONE;
+
+                data.baseColor =
+                    builder.read(baseColor,
+                                 framegraph::TextureRead {
+                                     .binding =
+                                         {
+                                             .location      = {.set = 3, .binding = 0},
+                                             .pipelineStage = framegraph::PipelineStage::eFragmentShader,
+                                         },
+                                     .type        = framegraph::TextureRead::Type::eCombinedImageSampler,
+                                     .imageAspect = rhi::ImageAspect::eColor,
+                                 });
+
+                data.color = builder.create<framegraph::FrameGraphTexture>(
+                    "General Gaussian Foveated Debug Overlay Color",
+                    {
+                        .extent     = resolution,
+                        .format     = rhi::PixelFormat::eRGBA8_UNorm,
+                        .layers     = useMultiview ? 2u : 0u,
+                        .usageFlags = rhi::ImageUsage::eRenderTarget | rhi::ImageUsage::eSampled,
+                    });
+                data.color = builder.write(data.color,
+                                           framegraph::Attachment {
+                                               .index       = 0,
+                                               .imageAspect = rhi::ImageAspect::eColor,
+                                               .clearValue  = framegraph::ClearValue::eOpaqueBlack,
+                                           });
+            },
+            [this, useMultiview, pushConstants](const PassData&, FrameGraphPassResources&, void* ctxPtr) {
+                VULTRA_SCOPED_FRAMEGRAPH_EXEC_CONTEXT(rc, ctxPtr);
+                setRenderDevice(rc.rd);
+                if (!rc.ext.builtinShaderLib)
+                    return;
+                setShaderLib(*rc.ext.builtinShaderLib);
+
+                RHI_GPU_ZONE(rc.cb, "GeneralGaussianSplatFoveatedDebugOverlayPass");
+
+                if (!rc.framebufferInfo().has_value())
+                    return;
+
+                const auto* pipeline = getPipeline(rhi::getColorFormat(rc.framebufferInfo().value(), 0),
+                                                   useMultiview,
+                                                   false,
+                                                   true);
+                if (!pipeline)
+                    return;
+
+                rc.overrideSampler(rc.resourceSet[3][0], rc.ext.samplers["nearest"]);
+
+                auto framebufferInfo = rc.framebufferInfo().value();
+                if (useMultiview)
+                {
+                    framebufferInfo.layers   = 2u;
+                    framebufferInfo.viewMask = 0x3u;
+                }
+
+                rc.cb.bindPipeline(*pipeline);
+                rc.bindDescriptorSets(*pipeline);
+                rc.cb.pushConstants(rhi::ShaderStages::eFragment, 0, &pushConstants);
+                rc.cb.beginRendering(framebufferInfo).drawFullScreenTriangle().endRendering();
+            });
+
+        return data.color;
+    }
+
     rhi::GraphicsPipeline GeneralGaussianSplatFoveatedCompositePass::createPipeline(
         const rhi::PixelFormat colorFormat,
         const bool             useMultiview,
-        const bool             useBase) const
+        const bool             useBase,
+        const bool             debugOverlay) const
     {
         auto vertexShader = loadGeneralShader("fullscreen_triangle.vert", vshadersystem::ShaderStage::eVert);
         if (!vertexShader)
@@ -202,11 +331,12 @@ namespace vultra
 
         rhi::ShaderLibraryRuntime::KeywordValues fragmentKeywords {
             {"USE_MULTIVIEW", useMultiview ? 1u : 0u},
-            {"USE_BASE", useBase ? 1u : 0u},
         };
-
+        if (!debugOverlay)
+            fragmentKeywords["USE_BASE"] = useBase ? 1u : 0u;
         auto fragmentShader =
-            loadGeneralShader("gaussian_splat_foveated_composite.frag",
+            loadGeneralShader(debugOverlay ? "gaussian_splat_foveated_debug_overlay.frag" :
+                                             "gaussian_splat_foveated_composite.frag",
                               vshadersystem::ShaderStage::eFrag,
                               fragmentKeywords);
         if (!fragmentShader)

--- a/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_preprocess_pass.cpp
+++ b/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_preprocess_pass.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <initializer_list>
 #include <vector>
 
@@ -21,6 +22,8 @@ namespace vultra
         constexpr auto PASS_NAME = "GeneralGaussianSplatPreprocessPass";
         constexpr auto kStereoCameraBinding = 23u;
         constexpr auto kFoveatedLayerCount = resource::kGeneralGaussianSplatFoveatedLayerCount;
+        constexpr auto kFoveatedClodEnabledFlag = 1u;
+        constexpr auto kFoveatedClodCoverageCompensationFlag = 8u;
         constexpr std::array<uint32_t, kFoveatedLayerCount> kFoveatedVisibleSplatBindings {31u, 32u, 33u};
         constexpr std::array<uint32_t, kFoveatedLayerCount> kFoveatedSortKeyBindings {34u, 35u, 36u};
         constexpr std::array<uint32_t, kFoveatedLayerCount> kFoveatedSortIndexBindings {37u, 38u, 39u};
@@ -33,22 +36,26 @@ namespace vultra
             uint32_t maxVisibleSplats {0};
             uint32_t rankTotalCount {0};
             uint32_t foveatedClodEnabled {0};
-            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 5.0f, 15.0f};
-            glm::vec4 foveatedLevelsAndTransition {1.0f, 0.25f, 0.05f, 2.0f};
+            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 8.0f, 24.0f};
+            glm::vec4 foveatedLevelsAndTransition {1.0f, 0.40f, 0.15f, 4.0f};
+            glm::uvec4 foveatedLayerParams {0u, 0u, 0u, 0u};
         };
 
         struct GeneralGaussianSplatFoveatedClodPushParams
         {
             uint32_t  enabled {0};
-            glm::vec4 gazeAndRings {0.5f, 0.5f, 5.0f, 15.0f};
-            glm::vec4 levelsAndTransition {1.0f, 0.25f, 0.05f, 2.0f};
+            glm::vec4 gazeAndRings {0.5f, 0.5f, 8.0f, 24.0f};
+            glm::vec4 levelsAndTransition {1.0f, 0.40f, 0.15f, 4.0f};
         };
 
         GeneralGaussianSplatFoveatedClodPushParams makeFoveatedClodPushParams(
             const resource::GpuSceneView& gpuSceneView)
         {
             GeneralGaussianSplatFoveatedClodPushParams params {};
-            params.enabled = gpuSceneView.generalGaussianSplatFoveatedClodEnabled ? 1u : 0u;
+            params.enabled = gpuSceneView.generalGaussianSplatFoveatedClodEnabled ? kFoveatedClodEnabledFlag : 0u;
+            if (gpuSceneView.generalGaussianSplatFoveatedClodEnabled &&
+                gpuSceneView.generalGaussianSplatFoveatedCoverageCompensationEnabled)
+                params.enabled |= kFoveatedClodCoverageCompensationFlag;
             params.gazeAndRings = glm::vec4 {gpuSceneView.generalGaussianSplatFoveatedGaze.x,
                                              gpuSceneView.generalGaussianSplatFoveatedGaze.y,
                                              gpuSceneView.generalGaussianSplatFoveatedRingDegrees.x,
@@ -78,7 +85,8 @@ namespace vultra
         const bool useMultiview =
             ctx.view().enableMultiview && ctx.view().multiviewCameraCount >= 2u && static_cast<bool>(stereoCameraBlock);
         const bool useDirectPrefix = gpuSceneView->generalGaussianSplatDirectPrefix;
-        const bool useFoveatedLayerOutput = gpuSceneView->generalGaussianSplatFoveatedLayeredCompositeEnabled;
+        const bool useFoveatedLayerOutput =
+            gpuSceneView->generalGaussianSplatFoveatedLayeredCompositeEnabled;
 
         if (gpuSceneView->generalGaussianSplatDrawBuffer)
         {
@@ -291,7 +299,6 @@ namespace vultra
                 hasAllFoveatedLayerResources() :
                 static_cast<bool>(visibleSplatBuffer && sortKeyBuffer && sortIndexBuffer && visibleCountBuffer &&
                                   indirectBuffer);
-
         if (!cameraBlock || !drawBuffer || !packedSourceBuffer || !hasOutputResources || !sortStorageBuffer ||
             !shBuffer || (!useDirectPrefix && !selectedSourceBuffer))
         {
@@ -535,20 +542,12 @@ namespace vultra
                             .dstAccess = rhi::Access::eShaderRead | rhi::Access::eShaderWrite,
                         });
 
-                    const auto* preprocessPipeline = getPipeline(useMultiview, useDirectPrefix, useFoveatedLayerOutput);
+                    const auto* preprocessPipeline =
+                        getPipeline(useMultiview, useDirectPrefix, useFoveatedLayerOutput);
                     if (!preprocessPipeline)
                     {
                         return;
                     }
-                    GeneralGaussianSplatPreprocessPushConstants pc {};
-                    pc.pointCount            = pointCount;
-                    pc.maxVisibleSplats      = maxVisible;
-                    pc.rankTotalCount        = rankTotalCount;
-                    pc.foveatedClodEnabled   = foveatedClodParams.enabled;
-                    pc.foveatedGazeAndRings  = foveatedClodParams.gazeAndRings;
-                    pc.foveatedLevelsAndTransition =
-                        foveatedClodParams.levelsAndTransition;
-
                     rc.cb.bindPipeline(*preprocessPipeline);
                     std::vector<uint32_t> preprocessBindings {0u, 13u, 14u, 22u};
                     if (useFoveatedLayerOutput)
@@ -570,9 +569,47 @@ namespace vultra
                         preprocessBindings.push_back(kStereoCameraBinding);
                     }
                     bindSubset(*preprocessPipeline, preprocessBindings);
-                    rc.cb.pushConstants(rhi::ShaderStages::eCompute, 0, &pc);
-                    const uint32_t dispatchX = (pointCount + 255u) / 256u;
-                    rc.cb.dispatch({dispatchX, 1u, 1u});
+
+                    auto dispatchPreprocess = [&](const uint32_t dispatchPointCount,
+                                                  const uint32_t foveatedOutputLayer) {
+                        if (dispatchPointCount == 0u)
+                            return;
+
+                        GeneralGaussianSplatPreprocessPushConstants pc {};
+                        pc.pointCount            = dispatchPointCount;
+                        pc.maxVisibleSplats      = maxVisible;
+                        pc.rankTotalCount        = rankTotalCount;
+                        pc.foveatedClodEnabled   = foveatedClodParams.enabled;
+                        pc.foveatedGazeAndRings  = foveatedClodParams.gazeAndRings;
+                        pc.foveatedLevelsAndTransition =
+                            foveatedClodParams.levelsAndTransition;
+                        pc.foveatedLayerParams = glm::uvec4 {foveatedOutputLayer, 0u, 0u, 0u};
+
+                        rc.cb.pushConstants(rhi::ShaderStages::eCompute, 0, &pc);
+                        const uint32_t dispatchX = (dispatchPointCount + 255u) / 256u;
+                        rc.cb.dispatch({dispatchX, 1u, 1u});
+                    };
+
+                    if (useFoveatedLayerOutput)
+                    {
+                        const auto layerPointCount = [&](const float level) {
+                            const float clampedLevel = std::clamp(level, 0.0f, 1.0f);
+                            if (clampedLevel <= 0.0f)
+                                return 0u;
+                            const auto budget =
+                                static_cast<uint32_t>(
+                                    std::ceil(static_cast<float>(rankTotalCount) * clampedLevel));
+                            return std::min(pointCount, std::max(1u, budget));
+                        };
+
+                        dispatchPreprocess(layerPointCount(foveatedClodParams.levelsAndTransition.x), 1u);
+                        dispatchPreprocess(layerPointCount(foveatedClodParams.levelsAndTransition.y), 2u);
+                        dispatchPreprocess(layerPointCount(foveatedClodParams.levelsAndTransition.z), 3u);
+                    }
+                    else
+                    {
+                        dispatchPreprocess(pointCount, 0u);
+                    }
                     rc.cb.insertComputeUavBarrier();
                 }
 

--- a/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_render_pass.cpp
+++ b/source/vultra/src/function/rendering/srp/builtin/passes/general_gaussian_splat_render_pass.cpp
@@ -21,8 +21,8 @@ namespace vultra
 
         struct GeneralGaussianSplatRenderPushConstants
         {
-            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 5.0f, 15.0f};
-            glm::vec4 foveatedParams {1.0f, 1.0f, 2.0f, 0.0f};
+            glm::vec4 foveatedGazeAndRings {0.5f, 0.5f, 8.0f, 24.0f};
+            glm::vec4 foveatedParams {1.0f, 1.0f, 4.0f, 0.0f};
             glm::vec4 targetSize {1.0f, 1.0f, 0.0f, 0.0f};
         };
 
@@ -36,13 +36,28 @@ namespace vultra
                               1.0f / std::max(std::abs(projection[1][1]), 1e-5f)};
         }
 
+        [[nodiscard]] float gaussianSplatFoveatedProjectionYSign(
+            const RenderView& view,
+            const rhi::RenderBackendApi backendApi)
+        {
+            if (!view.camera)
+                return 1.0f;
+
+            float sign = view.camera->projection[1][1] < 0.0f ? -1.0f : 1.0f;
+            if (backendApi == rhi::RenderBackendApi::eVulkan)
+                sign *= -1.0f;
+            return sign;
+        }
+
         [[nodiscard]] GeneralGaussianSplatRenderPushConstants makeRenderPushConstants(
             const RenderView&                       view,
             const resource::GpuSceneView&           gpuSceneView,
             const rhi::Extent2D                     targetSize,
-            const GeneralGaussianSplatFoveatedLayer layer)
+            const GeneralGaussianSplatFoveatedLayer layer,
+            const rhi::RenderBackendApi             backendApi)
         {
             const glm::vec2 tanHalfFov = gaussianSplatFoveatedTanHalfFov(view);
+            const float projectionYSign = gaussianSplatFoveatedProjectionYSign(view, backendApi);
 
             GeneralGaussianSplatRenderPushConstants pc {};
             pc.foveatedGazeAndRings =
@@ -54,12 +69,12 @@ namespace vultra
                 tanHalfFov.x,
                 tanHalfFov.y,
                 std::max(gpuSceneView.generalGaussianSplatFoveatedTransitionDegrees, 0.0f),
-                static_cast<float>(static_cast<uint32_t>(layer)),
+                static_cast<float>(layer),
             };
             pc.targetSize = glm::vec4 {
                 static_cast<float>(std::max(targetSize.width, 1u)),
                 static_cast<float>(std::max(targetSize.height, 1u)),
-                0.0f,
+                projectionYSign,
                 0.0f,
             };
             return pc;
@@ -76,7 +91,8 @@ namespace vultra
     FrameGraphResource GeneralGaussianSplatRenderPass::addFoveatedLayerPass(
         FrameGraphBuildContext&                ctx,
         const GeneralGaussianSplatFoveatedLayer layer,
-        const rhi::Extent2D                    resolution)
+        const rhi::Extent2D                    resolution,
+        const FrameGraphResource               existingColorOverride)
     {
         auto* gpuSceneView = ctx.view().gpuSceneView;
         if (!gpuSceneView || !gpuSceneView->hasGeneralGaussianSplats())
@@ -94,7 +110,8 @@ namespace vultra
         auto indirectBuffer = useFoveatedLayerResources ?
                                   ctx.data.tryGet(kResKey_GeneralGaussianSplatFoveatedIndirectBuffers[layerIndex - 1u]) :
                                   ctx.data.tryGet(kResKey_GeneralGaussianSplatIndirectBuffer);
-        auto existingColor      = layer == GeneralGaussianSplatFoveatedLayer::eDisabled ?
+        auto existingColor = existingColorOverride ? existingColorOverride :
+                             layer == GeneralGaussianSplatFoveatedLayer::eDisabled ?
                                       ctx.data.tryGet(kResKey_FinalCompositionSource) :
                                       FrameGraphResource {};
         if (!visibleSplatBuffer || !sortIndexBuffer || !indirectBuffer)
@@ -106,7 +123,13 @@ namespace vultra
             layer == GeneralGaussianSplatFoveatedLayer::eFovea    ? "GeneralGaussianSplatFoveaLayerPass" :
             layer == GeneralGaussianSplatFoveatedLayer::eMid      ? "GeneralGaussianSplatMidLayerPass" :
                                                                     "GeneralGaussianSplatOuterLayerPass";
-        const auto pushConstants = makeRenderPushConstants(ctx.view(), *gpuSceneView, resolution, layer);
+        const auto pushConstants =
+            makeRenderPushConstants(
+                ctx.view(),
+                *gpuSceneView,
+                resolution,
+                layer,
+                ctx.rd.getBackendApi());
 
         struct PassData
         {
@@ -118,7 +141,13 @@ namespace vultra
 
         auto data = ctx.fg.addCallbackPass<PassData>(
             passName,
-            [passName, resolution, useMultiview, visibleSplatBuffer, sortIndexBuffer, indirectBuffer, existingColor](
+            [passName,
+             resolution,
+             useMultiview,
+             visibleSplatBuffer,
+             sortIndexBuffer,
+             indirectBuffer,
+             existingColor](
                 FrameGraph::Builder& builder, PassData& data) {
                 PASS_SETUP_ZONE;
 
@@ -190,7 +219,8 @@ namespace vultra
 
                 rhi::prepareForDrawingIndirect(rc.cb, *indirectBuf);
 
-                const auto* pipeline = getPipeline(rhi::getColorFormat(rc.framebufferInfo().value(), 0), useMultiview);
+                const auto* pipeline =
+                    getPipeline(rhi::getColorFormat(rc.framebufferInfo().value(), 0), useMultiview);
                 if (!pipeline)
                 {
                     return;
@@ -228,7 +258,8 @@ namespace vultra
         if (!vertexShader)
             return {};
 
-        auto fragmentShader = loadGeneralShader("gaussian_splat_render.frag", vshadersystem::ShaderStage::eFrag, {});
+        auto fragmentShader =
+            loadGeneralShader("gaussian_splat_render.frag", vshadersystem::ShaderStage::eFrag);
         if (!fragmentShader)
             return {};
 

--- a/source/vultra/src/function/rendering/srp/builtin/universal_renderer.cpp
+++ b/source/vultra/src/function/rendering/srp/builtin/universal_renderer.cpp
@@ -79,6 +79,59 @@ namespace vultra
             return "Unknown";
         }
 
+        [[nodiscard]] const char* gaussianFoveatedAdaptationModeLabel(
+            const GaussianSplatFoveatedAdaptationMode mode)
+        {
+            switch (mode)
+            {
+                case GaussianSplatFoveatedAdaptationMode::eFixed:
+                    return "Fixed";
+                case GaussianSplatFoveatedAdaptationMode::eDynamicBudget:
+                    return "Dynamic Budget";
+                case GaussianSplatFoveatedAdaptationMode::eDynamicRange:
+                    return "Dynamic Range";
+            }
+            return "Unknown";
+        }
+
+        [[nodiscard]] bool gaussianManualGazeControlActive(const GaussianSplatRenderSettings& settings)
+        {
+            return settings.foveatedClodActive() && settings.foveatedManualGazeControlEnabled;
+        }
+
+        void drawGaussianManualGazeOverlay(GaussianSplatRenderSettings& settings)
+        {
+            if (!gaussianManualGazeControlActive(settings))
+                return;
+
+            const ImGuiViewport* viewport = ImGui::GetMainViewport();
+            if (!viewport || viewport->Size.x <= 0.0f || viewport->Size.y <= 0.0f)
+                return;
+
+            auto& io = ImGui::GetIO();
+            const ImVec2 mouse = io.MousePos;
+            const ImVec2 viewMin = viewport->Pos;
+            const ImVec2 viewSize = io.DisplaySize.x > 0.0f && io.DisplaySize.y > 0.0f ? io.DisplaySize :
+                                                                                         viewport->Size;
+            const ImVec2 viewMax {viewMin.x + viewSize.x, viewMin.y + viewSize.y};
+            const bool   mouseInside =
+                mouse.x >= viewMin.x && mouse.x <= viewMax.x && mouse.y >= viewMin.y && mouse.y <= viewMax.y;
+
+            if (mouseInside && !io.WantCaptureMouse && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+            {
+                settings.foveatedGaze.x = std::clamp((mouse.x - viewMin.x) / viewSize.x, 0.0f, 1.0f);
+                settings.foveatedGaze.y = std::clamp((mouse.y - viewMin.y) / viewSize.y, 0.0f, 1.0f);
+            }
+
+            const ImVec2 gaze {
+                viewMin.x + settings.foveatedGaze.x * viewSize.x,
+                viewMin.y + settings.foveatedGaze.y * viewSize.y,
+            };
+            ImDrawList* drawList = ImGui::GetForegroundDrawList();
+            drawList->AddCircleFilled(gaze, 5.0f, IM_COL32(255, 32, 32, 255), 24);
+            drawList->AddCircle(gaze, 8.0f, IM_COL32(255, 255, 255, 220), 24, 1.5f);
+        }
+
         [[nodiscard]] double findScopeGpuMs(const std::vector<RuntimeProfiler::ScopeNode>& nodes,
                                             const char*                                    namePart)
         {
@@ -144,16 +197,33 @@ namespace vultra
             const bool gazeControlsEnabled = orderedClodEnabled && settings.foveatedClodEnabled;
             if (!gazeControlsEnabled)
                 ImGui::BeginDisabled();
-            constexpr const char* kFoveatedModeLabels[] = {"Single Pass", "Layered Composite"};
-            int foveatedModeIndex = static_cast<int>(settings.foveatedRenderMode);
-            if (ImGui::Combo("Gaze Render Path",
-                             &foveatedModeIndex,
-                             kFoveatedModeLabels,
-                             IM_ARRAYSIZE(kFoveatedModeLabels)))
+            struct RenderPathOption
             {
-                foveatedModeIndex = std::clamp(foveatedModeIndex, 0, IM_ARRAYSIZE(kFoveatedModeLabels) - 1);
-                settings.foveatedRenderMode = static_cast<GaussianSplatFoveatedRenderMode>(foveatedModeIndex);
+                GaussianSplatFoveatedRenderMode mode;
+                const char*                     label;
+            };
+            constexpr RenderPathOption kRenderPathOptions[] = {
+                {GaussianSplatFoveatedRenderMode::eSinglePass, "Single Pass"},
+                {GaussianSplatFoveatedRenderMode::eLayeredComposite, "Layered Composite"},
+            };
+            if (ImGui::BeginCombo("Gaze Render Path",
+                                  gaussianFoveatedRenderModeLabel(settings.foveatedRenderMode)))
+            {
+                for (const auto& option : kRenderPathOptions)
+                {
+                    const bool selected = settings.foveatedRenderMode == option.mode;
+                    if (ImGui::Selectable(option.label, selected))
+                        settings.foveatedRenderMode = option.mode;
+                    if (selected)
+                        ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
             }
+            if (ImGui::Button("Apply Fov-GS Baseline"))
+                applyGaussianSplatFovGsStyleBaseline(settings);
+            ImGui::Checkbox("Coverage Compensation", &settings.foveatedCoverageCompensationEnabled);
+            ImGui::Checkbox("Gaze Color Overlay", &settings.foveatedDebugOverlayEnabled);
+            ImGui::Checkbox("Manual Gaze Point", &settings.foveatedManualGazeControlEnabled);
             ImGui::SliderFloat2("Gaze UV", &settings.foveatedGaze.x, 0.0f, 1.0f, "%.2f");
             ImGui::SliderFloat("Fovea Degrees", &settings.foveatedRingDegrees.x, 0.0f, 45.0f, "%.1f");
             ImGui::SliderFloat("Mid Degrees", &settings.foveatedRingDegrees.y, 0.0f, 90.0f, "%.1f");
@@ -167,9 +237,22 @@ namespace vultra
             ImGui::SliderFloat("Mid Resolution", &settings.foveatedResolutionScales.y, 0.05f, 1.0f, "%.2f");
             ImGui::SliderFloat("Outer Resolution", &settings.foveatedResolutionScales.z, 0.05f, 1.0f, "%.2f");
             ImGui::SliderFloat("Transition Degrees", &settings.foveatedTransitionDegrees, 0.0f, 10.0f, "%.1f");
-            ImGui::Checkbox("Adaptive Budget", &settings.foveatedBudgetControllerEnabled);
+            constexpr const char* kAdaptationLabels[] = {"Fixed", "Dynamic Budget", "Dynamic Range"};
+            int adaptationIndex = static_cast<int>(settings.foveatedAdaptationMode);
+            if (ImGui::Combo("Gaze Adaptation", &adaptationIndex, kAdaptationLabels, IM_ARRAYSIZE(kAdaptationLabels)))
+            {
+                adaptationIndex = std::clamp(adaptationIndex, 0, IM_ARRAYSIZE(kAdaptationLabels) - 1);
+                settings.foveatedAdaptationMode =
+                    static_cast<GaussianSplatFoveatedAdaptationMode>(adaptationIndex);
+            }
+            const bool adaptationEnabled =
+                settings.foveatedAdaptationMode != GaussianSplatFoveatedAdaptationMode::eFixed;
+            if (!adaptationEnabled)
+                ImGui::BeginDisabled();
             ImGui::SliderFloat("Target Frame", &settings.foveatedTargetFrameMs, 1.0f, 33.3f, "%.1f ms");
-            ImGui::SliderFloat("Budget Step", &settings.foveatedBudgetAdjustRate, 0.001f, 0.25f, "%.3f");
+            ImGui::SliderFloat("Adaptation Step", &settings.foveatedBudgetAdjustRate, 0.001f, 0.25f, "%.3f");
+            if (!adaptationEnabled)
+                ImGui::EndDisabled();
             settings.foveatedGaze.x = std::clamp(settings.foveatedGaze.x, 0.0f, 1.0f);
             settings.foveatedGaze.y = std::clamp(settings.foveatedGaze.y, 0.0f, 1.0f);
             settings.foveatedRingLevels.x = std::clamp(settings.foveatedRingLevels.x, 0.0f, 1.0f);
@@ -188,9 +271,14 @@ namespace vultra
             ImGui::Text("Mode: %s", gaussianBaselineModeLabel(stats.baselineMode));
             ImGui::Text("Gaze Rendering: %s", stats.foveatedClodEnabled ? "yes" : "no");
             ImGui::Text("Gaze Render Path: %s", gaussianFoveatedRenderModeLabel(stats.foveatedRenderMode));
+            ImGui::Text("Coverage Compensation: %s",
+                        stats.foveatedCoverageCompensationEnabled ? "yes" : "no");
+            ImGui::Text("Gaze Color Overlay: %s", stats.foveatedDebugOverlayEnabled ? "yes" : "no");
+            ImGui::Text("Gaze UV: %.2f / %.2f", stats.foveatedGaze.x, stats.foveatedGaze.y);
             ImGui::Text("Layered Framebuffers: %s", stats.foveatedLayeredCompositeEnabled ? "yes" : "no");
-            ImGui::Text("Adaptive Budget: %s", stats.foveatedBudgetControllerEnabled ? "yes" : "no");
+            ImGui::Text("Gaze Adaptation: %s", gaussianFoveatedAdaptationModeLabel(stats.foveatedAdaptationMode));
             ImGui::Text("Direct Prefix: %s", stats.directPrefix ? "yes" : "no");
+            ImGui::Text("Ring Degrees: %.1f / %.1f", stats.foveatedRingDegrees.x, stats.foveatedRingDegrees.y);
             ImGui::Text("Ring LODs: %.2f / %.2f / %.2f",
                         stats.foveatedRingLevels.x,
                         stats.foveatedRingLevels.y,
@@ -201,6 +289,10 @@ namespace vultra
                         stats.foveatedResolutionScales.z);
             ImGui::Text("Total Splats: %u", stats.totalSplats);
             ImGui::Text("Prepared Splats: %u", stats.preparedSplats);
+            ImGui::Text("Ring Budgets: %u / %u / %u",
+                        stats.foveaSplatBudget,
+                        stats.midSplatBudget,
+                        stats.outerSplatBudget);
             ImGui::Text("Visible Cap: %u", stats.maxVisibleSplatCap);
             ImGui::Text("Draw Records: %u", stats.drawRecords);
             ImGui::Text("LOD Raw Splats: %u", stats.lodSelectedRawSplats);
@@ -679,7 +771,8 @@ namespace vultra
         auto& renderService  = services->require<IRenderService>();
         auto& gpuResourceSvc = services->require<IGpuResourceService>();
 
-        const bool suppressCameraInput = ImGui::GetIO().WantCaptureMouse || ImGui::IsAnyItemHovered() ||
+        const bool suppressCameraInput = gaussianManualGazeControlActive(renderService.gaussianSplatSettings()) ||
+                                         ImGui::GetIO().WantCaptureMouse || ImGui::IsAnyItemHovered() ||
                                          ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow);
         cameraService.setCameraControlInputSuppressed(suppressCameraInput);
 
@@ -688,6 +781,7 @@ namespace vultra
         ImGui::Begin("Universal Renderer");
 
         drawGaussianSplatBaselinePanel(renderService);
+        drawGaussianManualGazeOverlay(renderService.gaussianSplatSettings());
 
         if (backendService.isXREnabled() && backendService.isXRMirrorEnabled())
         {

--- a/source/vultra/src/platform/sdl/sdl_window.cpp
+++ b/source/vultra/src/platform/sdl/sdl_window.cpp
@@ -125,6 +125,8 @@ namespace vultra::platform::sdl
         }
         applyCursorVisibility();
         applyCursor();
+        SDL_GetWindowSize(m_WindowHandle, &m_Extent.x, &m_Extent.y);
+        SDL_GetWindowPosition(m_WindowHandle, &m_Position.x, &m_Position.y);
         SDL_GetWindowSizeInPixels(m_WindowHandle, &m_FrameBufferExtent.x, &m_FrameBufferExtent.y);
 
         VULTRA_CORE_INFO(
@@ -496,14 +498,21 @@ namespace vultra::platform::sdl
                     break;
 
                 case SDL_EVENT_WINDOW_RESIZED:
-                    m_Extent = {event.window.data1, event.window.data2};
+                    SDL_GetWindowSize(m_WindowHandle, &m_Extent.x, &m_Extent.y);
+                    SDL_GetWindowSizeInPixels(m_WindowHandle, &m_FrameBufferExtent.x, &m_FrameBufferExtent.y);
+                    generalEvent.type = event::WindowEventType::eResized;
+                    emitEvent(generalEvent);
+                    break;
+
+                case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+                    SDL_GetWindowSize(m_WindowHandle, &m_Extent.x, &m_Extent.y);
                     SDL_GetWindowSizeInPixels(m_WindowHandle, &m_FrameBufferExtent.x, &m_FrameBufferExtent.y);
                     generalEvent.type = event::WindowEventType::eResized;
                     emitEvent(generalEvent);
                     break;
 
                 case SDL_EVENT_WINDOW_MOVED:
-                    m_Position        = {event.window.data1, event.window.data2};
+                    SDL_GetWindowPosition(m_WindowHandle, &m_Position.x, &m_Position.y);
                     generalEvent.type = event::WindowEventType::eMoved;
                     emitEvent(generalEvent);
                     break;


### PR DESCRIPTION
## Summary
- Move foveated layered CLOD budgets into the Gaussian preprocess stage
- Dispatch fovea / mid / outer layers separately so each layer only preprocesses its own budget
- Add early ring culling before covariance / SH / footprint work
- Keep single-pass rendering behavior unchanged
- Add debug overlay and benchmark fields for validating gaze-ring behavior and runtime cost

## Validation
- Built `example-gaussian-splatting`
- Benchmarked playroom layered-composite path

Before:
- GPU frame p50: 0.8356 ms
- GPU frame p95: 1.5158 ms
- GPU preprocess p50: 0.0224 ms
- GPU render p50: 0.7126 ms

After:
- GPU frame p50: 0.4718 ms
- GPU frame p95: 0.9771 ms
- GPU preprocess p50: 0.0103 ms
- GPU render p50: 0.3991 ms